### PR TITLE
Upgrade patroni version

### DIFF
--- a/pg15/Dockerfile
+++ b/pg15/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get install -y alien
 
 RUN cat /root/.pip/pip.conf
 RUN python3 -m pip install -U setuptools==70.0.0
-RUN python3 -m pip install psutil patroni[kubernetes,etcd]==4.0.4 psycopg2-binary==2.9.5 requests python-dateutil urllib3 six prettytable --no-cache
+RUN python3 -m pip install psutil patroni[kubernetes,etcd]==3.3.5 psycopg2-binary==2.9.5 requests python-dateutil urllib3 six prettytable --no-cache
 RUN mv /var/lib/postgresql /var/lib/pgsql
 
 RUN mkdir /patroni && chmod -R 777 /patroni/ && \

--- a/pg16/Dockerfile
+++ b/pg16/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get install -y alien
 
 RUN cat /root/.pip/pip.conf
 RUN python3 -m pip install -U setuptools==70.0.0
-RUN python3 -m pip install psutil patroni[kubernetes,etcd]==4.0.4 psycopg2-binary==2.9.5 requests python-dateutil urllib3 six prettytable --no-cache
+RUN python3 -m pip install psutil patroni[kubernetes,etcd]==3.3.5 psycopg2-binary==2.9.5 requests python-dateutil urllib3 six prettytable --no-cache
 RUN mv /var/lib/postgresql /var/lib/pgsql
 
 RUN mkdir /patroni && chmod -R 777 /patroni/ && \


### PR DESCRIPTION
This issue arises due to incompatibility of ydiff and patroni version. In our service we are having ydiff version 1.4.2 which was incompatible with patroni 3.3.2 and was fixed to made compatible with patroni 3.3.5 - https://github.com/patroni/patroni/commit/202ae44ef487f6bc22e2188f21d38bc62197ae85
So, we have upgraded patroni version to 3.3.5 within scope of this ticket.